### PR TITLE
Add telegram news digest bot with Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TELEGRAM_TOKEN=your-telegram-token-here

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY bot ./bot
+ENV TELEGRAM_TOKEN=
+CMD ["python", "-m", "bot.main"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Hackathon_VNEDREID
+# Telegram News Digest Bot
+
+This repository contains a simple Telegram bot that allows users to subscribe to stock tickers and receive news digests.
+
+## Features
+- `/start` and `/help` for instructions
+- `/subscribe <TICKER>` and `/unsubscribe <TICKER>` to manage subscriptions
+- `/digest` to fetch the latest news for subscribed tickers
+- `/rank` to show the most popular tickers
+
+Subscriptions are stored in a SQLite database for persistence.
+
+## Running with Docker
+
+1. Copy `.env.example` to `.env` and fill in your Telegram bot token.
+   ```bash
+   cp .env.example .env
+   ```
+2. Build the image:
+   ```bash
+   docker build -t telegram-digest-bot .
+   ```
+3. Run the container:
+   ```bash
+   docker run --env-file .env telegram-digest-bot
+   ```
+
+The bot will start polling Telegram for updates.

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,173 @@
+import os
+import logging
+import sqlite3
+import feedparser
+from newspaper import Article
+from sumy.parsers.plaintext import PlaintextParser
+from sumy.nlp.tokenizers import Tokenizer
+from sumy.summarizers.lsa import LsaSummarizer
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'subscriptions.db')
+
+logging.basicConfig(level=logging.INFO)
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS subscriptions (user_id INTEGER, ticker TEXT, UNIQUE(user_id, ticker))'
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_subscription(user_id: int, ticker: str):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'INSERT OR IGNORE INTO subscriptions (user_id, ticker) VALUES (?, ?)',
+        (user_id, ticker.upper()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def remove_subscription(user_id: int, ticker: str):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'DELETE FROM subscriptions WHERE user_id=? AND ticker=?',
+        (user_id, ticker.upper()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_subscriptions(user_id: int):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT ticker FROM subscriptions WHERE user_id=?', (user_id,))
+    rows = c.fetchall()
+    conn.close()
+    return [row[0] for row in rows]
+
+
+def get_rankings():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'SELECT ticker, COUNT(*) as cnt FROM subscriptions GROUP BY ticker ORDER BY cnt DESC'
+    )
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def summarize_text(text: str, sentences: int = 3) -> str:
+    parser = PlaintextParser.from_string(text, Tokenizer('english'))
+    summarizer = LsaSummarizer()
+    summary = summarizer(parser.document, sentences)
+    return ' '.join(str(sentence) for sentence in summary)
+
+
+def get_news_digest(ticker: str, limit: int = 3) -> str:
+    feed_url = f'https://news.google.com/rss/search?q={ticker}'
+    feed = feedparser.parse(feed_url)
+    articles = []
+    for entry in feed.entries[:limit]:
+        url = entry.link
+        try:
+            article = Article(url)
+            article.download()
+            article.parse()
+            summary = summarize_text(article.text)
+            articles.append(f"*{entry.title}*\n{summary}\n{url}")
+        except Exception as e:
+            logging.error('Failed to process article %s: %s', url, e)
+            articles.append(f"{entry.title}\n{url}")
+    if not articles:
+        return 'No articles found.'
+    return '\n\n'.join(articles)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        'Welcome! Use /subscribe <TICKER> to subscribe to news updates. '
+        'Commands: /subscribe, /unsubscribe, /digest, /rank, /help'
+    )
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        '/start - Welcome message\n'
+        '/subscribe <TICKER> - Subscribe to a ticker\n'
+        '/unsubscribe <TICKER> - Unsubscribe from a ticker\n'
+        '/digest - Get news digest for your subscriptions\n'
+        '/rank - Show most subscribed tickers\n'
+        '/help - Show this help message'
+    )
+
+
+async def subscribe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text('Usage: /subscribe <TICKER>')
+        return
+    ticker = context.args[0]
+    add_subscription(update.effective_user.id, ticker)
+    await update.message.reply_text(f'Subscribed to {ticker.upper()}')
+
+
+async def unsubscribe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text('Usage: /unsubscribe <TICKER>')
+        return
+    ticker = context.args[0]
+    remove_subscription(update.effective_user.id, ticker)
+    await update.message.reply_text(f'Unsubscribed from {ticker.upper()}')
+
+
+async def digest(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    tickers = get_subscriptions(update.effective_user.id)
+    if not tickers:
+        await update.message.reply_text('You have no subscriptions.')
+        return
+    messages = []
+    for t in tickers:
+        digest_text = get_news_digest(t)
+        messages.append(f'*{t}*\n{digest_text}')
+    await update.message.reply_text('\n\n'.join(messages), parse_mode='Markdown')
+
+
+async def rank(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    ranking = get_rankings()
+    if not ranking:
+        await update.message.reply_text('No subscriptions yet.')
+        return
+    lines = [f'{idx+1}. {ticker} - {count}' for idx, (ticker, count) in enumerate(ranking)]
+    await update.message.reply_text('\n'.join(lines))
+
+
+def main():
+    token = os.getenv('TELEGRAM_TOKEN')
+    if not token:
+        raise RuntimeError('TELEGRAM_TOKEN not set')
+
+    init_db()
+
+    app = ApplicationBuilder().token(token).build()
+
+    app.add_handler(CommandHandler('start', start))
+    app.add_handler(CommandHandler('help', help_command))
+    app.add_handler(CommandHandler('subscribe', subscribe))
+    app.add_handler(CommandHandler('unsubscribe', unsubscribe))
+    app.add_handler(CommandHandler('digest', digest))
+    app.add_handler(CommandHandler('rank', rank))
+
+    app.run_polling()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+python-telegram-bot>=20.0
+feedparser
+newspaper3k
+sumy
+python-dotenv


### PR DESCRIPTION
## Summary
- build a Telegram news digest bot using `python-telegram-bot`
- keep user subscriptions in SQLite
- fetch news and summarize with feedparser and newspaper
- include Dockerfile and environment variable example
- document how to build and run the bot container

## Testing
- `python -m py_compile bot/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844281af1788328a2954afb15e7593c