### PR TITLE
Fix subscription DB usage and helper functions

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -34,7 +34,26 @@ def add_subscription(user_id: int, ticker: str):
         (user_id, ticker.upper()),
     )
     conn.commit()
+    c.execute('SELECT ticker FROM subscriptions WHERE user_id=?', (user_id,))
+    rows = c.fetchall()
     conn.close()
+    return [row[0] for row in rows]
+
+
+def remove_subscription(user_id: int, ticker: str) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'DELETE FROM subscriptions WHERE user_id=? AND ticker=?',
+        (user_id, ticker.upper()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_subscriptions(user_id: int):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
     c.execute('SELECT ticker FROM subscriptions WHERE user_id=?', (user_id,))
     rows = c.fetchall()
     conn.close()


### PR DESCRIPTION
## Summary
- fix closing DB connection in `add_subscription`
- add `remove_subscription` and `get_subscriptions` helpers

## Testing
- `python -m py_compile bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68444c1e4ac0832bab5df7e4a5ba7a80