### PR TITLE
Add news CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@
 
 После запуска бот начнёт опрашивать Telegram и реагировать на команды пользователей.
 
+Все собранные новости сохраняются в два CSV-файла:
+`articles.csv` содержит исходные данные, а `news.csv` совместим
+с таблицей `news` в PostgreSQL. Его можно загрузить так:
+
+```bash
+psql -d mydb -c "\COPY news(title,body,published_at,source,news_type,region,topics,related_markets,macro_sensitive,likely_to_influence,influence_reason) FROM 'news.csv' CSV HEADER"
+```
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 from .rss_collector import collect_ticker_news, collect_recent_news
 
-from .storage import save_articles_to_csv
+from .storage import save_articles_to_csv, save_news_to_csv
 
 DB_PATH = os.path.join(os.path.dirname(__file__), 'subscriptions.db')
 
@@ -111,6 +111,7 @@ def get_news_digest(ticker: str, limit: int = 3) -> str:
         return 'Статьи не найдены.'
 
     save_articles_to_csv(articles_data)
+    save_news_to_csv(articles_data)
 
     digest_parts = []
     for art in articles_data[:limit]:
@@ -203,6 +204,7 @@ async def news(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     save_articles_to_csv(articles)
+    save_news_to_csv(articles)
 
     lines = [f"*{a['title']}*\n{a['link']}" for a in articles[:10]]
     await update.message.reply_text('\n\n'.join(lines), parse_mode='Markdown')

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -1,6 +1,19 @@
 import os
 import sqlite3
 import pandas as pd
+from datetime import datetime, timezone
+
+
+def _format_datetime(dt_str: str) -> str:
+    """Return ISO formatted datetime with timezone or empty string."""
+    if not dt_str:
+        return ""
+    try:
+        dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
+        dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
+    except Exception:
+        return dt_str
 
 
 def save_articles_to_csv(articles, path="articles.csv"):
@@ -44,3 +57,44 @@ def save_articles_to_db(articles, db_path="articles.db"):
     conn.commit()
     conn.close()
     return db_path
+
+
+def save_news_to_csv(articles, path="news.csv"):
+    """Save articles to a CSV compatible with the Postgres `news` table."""
+    if not articles:
+        return
+    rows = []
+    for a in articles:
+        rows.append(
+            {
+                "title": a.get("title", ""),
+                "body": a.get("text", ""),
+                "published_at": _format_datetime(a.get("date", "")),
+                "source": a.get("source", ""),
+                "news_type": "corporate",
+                "region": "",
+                "topics": "{}",
+                "related_markets": "{}",
+                "macro_sensitive": "false",
+                "likely_to_influence": "false",
+                "influence_reason": "",
+            }
+        )
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "title",
+            "body",
+            "published_at",
+            "source",
+            "news_type",
+            "region",
+            "topics",
+            "related_markets",
+            "macro_sensitive",
+            "likely_to_influence",
+            "influence_reason",
+        ],
+    )
+    df.to_csv(path, index=False, encoding="utf-8")
+    return path


### PR DESCRIPTION
## Summary
- export articles to `news.csv` in Postgres-friendly format
- save collected news into both `articles.csv` and `news.csv`
- document new CSV in README

## Testing
- `python -m py_compile bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68446f1f7418832b847df2d9e5ed5486