### PR TITLE
Restore chart command and help text

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -192,12 +192,13 @@ async def handle_menu_button(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-
-    await update.message.reply_text(
-        '/start - приветственное сообщение\n'
+    """Send detailed help grouped by topics."""
+    help_text = (
+        'Доступные команды:\n\n'
+        '*Управление подписками*\n'
         '/subscribe <TICKER> [...] - подписаться на один или несколько тикеров\n'
-        '/unsubscribe <TICKER> - отписаться от тикера\n'
-        '/subs - показать текущие подписки\n'
+        '/unsubscribe <TICKER> - отписаться от тикера\n\n'
+        '*Новости*\n'
         '/digest - получить новостной дайджест по подпискам\n'
         '/rank - показать самые популярные тикеры\n'
         '/news [hours|days|weeks N] - свежие новости за период\n'
@@ -328,6 +329,24 @@ async def handle_token_message(update: Update, context: ContextTypes.DEFAULT_TYP
             logging.error('Failed to save portfolio: %s', e)
     await update.message.reply_text(f'```\n{text}\n```', parse_mode='Markdown')
     await update.message.reply_text('Тикеры портфеля добавлены в подписки.')
+
+
+async def chart(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a portfolio chart for the user."""
+    user_id = update.effective_user.id
+    token = await load_token(user_id)
+    if not token:
+        WAITING_TOKEN.add(user_id)
+        await update.message.reply_text('Отправьте токен Тинькофф Инвест в формате t.*')
+        return
+    await update.message.reply_text('Строю график, пожалуйста подождите...')
+    rows = await get_portfolio_data(token)
+    buf = make_portfolio_chart(rows)
+    if not buf:
+        await update.message.reply_text('Не удалось построить график.')
+        return
+    buf.name = 'portfolio.png'
+    await update.message.reply_photo(buf)
 
 
 async def history(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- fix `help_command` by restoring lost help text variable
- reintroduce `chart` command to generate portfolio diagram

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684552c181ac83289bb07275ff2847d4