### PR TITLE
Simplify history command

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -352,7 +352,9 @@ async def chart(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def history(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Send price history chart for a ticker."""
     if not context.args:
-        await update.message.reply_text('Использование: /history <TICKER> [days]')
+        await update.message.reply_text(
+            'Использование: /history <TICKER> [days]'
+        )
         return
     ticker = context.args[0]
     days = 30

--- a/bot/market.py
+++ b/bot/market.py
@@ -25,7 +25,14 @@ def _fetch_history(token: str, ticker: str, days: int) -> List[Dict]:
             interval=CandleInterval.CANDLE_INTERVAL_DAY,
         )
         data = [
-            {"date": c.time.date(), "close": _q_to_float(c.close)} for c in resp.candles
+            {
+                "date": c.time.date(),
+                "open": _q_to_float(c.open),
+                "high": _q_to_float(c.high),
+                "low": _q_to_float(c.low),
+                "close": _q_to_float(c.close),
+            }
+            for c in resp.candles
         ]
         return data
 

--- a/bot/plotting.py
+++ b/bot/plotting.py
@@ -4,6 +4,8 @@ from typing import List, Dict
 import matplotlib
 matplotlib.use('Agg')  # headless backend
 import matplotlib.pyplot as plt
+import pandas as pd
+import mplfinance as mpf
 
 def make_portfolio_chart(rows: List[Dict]) -> io.BytesIO | None:
     """Return a bar chart image for portfolio data as BytesIO."""
@@ -31,24 +33,68 @@ def make_portfolio_chart(rows: List[Dict]) -> io.BytesIO | None:
     return buf
 
 
+def _smma(values: List[float], period: int) -> List[float]:
+    if len(values) < period:
+        return [None] * len(values)
+    res = [None] * (period - 1)
+    sma = sum(values[:period]) / period
+    res.append(sma)
+    for i in range(period, len(values)):
+        prev = res[-1]
+        val = (prev * (period - 1) + values[i]) / period
+        res.append(val)
+    return res
+
+
 def make_price_history_chart(points: List[Dict]) -> io.BytesIO | None:
-    """Return a line chart image for ticker price history."""
+    """Return a candlestick chart image with Alligator indicator."""
     if not points:
         return None
-    dates = [p.get("date") for p in points]
-    closes = [p.get("close") for p in points]
-    if not closes:
+    df = pd.DataFrame(points)
+    if not {"open", "high", "low", "close", "date"}.issubset(df.columns):
         return None
-    fig, ax = plt.subplots(figsize=(8, 4))
-    ax.plot(dates, closes, marker="o", color="green")
-    ax.set_title("Price history")
-    ax.set_xlabel("Date")
-    ax.set_ylabel("Close price")
-    ax.tick_params(axis="x", rotation=45)
-    ax.grid(True)
-    plt.tight_layout()
+    df["date"] = pd.to_datetime(df["date"])
+    df.set_index("date", inplace=True)
+    median = (df["high"] + df["low"]) / 2
+    df["jaw"] = pd.Series(_smma(median.tolist(), 21)).shift(8)
+    df["teeth"] = pd.Series(_smma(median.tolist(), 11)).shift(5)
+    df["lips"] = pd.Series(_smma(median.tolist(), 8)).shift(3)
+
+    apds = [
+        mpf.make_addplot(df["jaw"], color="skyblue"),
+        mpf.make_addplot(df["teeth"], color="red"),
+        mpf.make_addplot(df["lips"], color="green"),
+    ]
+
+    style = mpf.make_mpf_style(base_mpf_style="nightclouds", gridstyle=":")
+    fig, axlist = mpf.plot(
+        df,
+        type="candle",
+        style=style,
+        addplot=apds,
+        returnfig=True,
+        ylabel="Price",
+        tight_layout=True,
+        upcolor="green",
+        downcolor="red",
+    )
+    ax = axlist[0]
+
+    last = df.iloc[-1]
+    labels = [
+        f"O:{last['open']:.2f}",
+        f"H:{last['high']:.2f}",
+        f"L:{last['low']:.2f}",
+        f"C:{last['close']:.2f}",
+    ]
+    for name in ("jaw", "teeth", "lips"):
+        val = last[name]
+        if pd.notna(val):
+            labels.append(f"{name}:{val:.2f}")
+    ax.legend(labels, fontsize="small")
+
     buf = io.BytesIO()
-    plt.savefig(buf, format="png")
+    fig.savefig(buf, format="png")
     plt.close(fig)
     buf.seek(0)
     return buf

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ tinkoff-investments
 
 tinkoff-investments>=0.2.0b113
 matplotlib
+mplfinance
 google-generativeai


### PR DESCRIPTION
## Summary
- simplify `/history` to only accept ticker and days
- draw candlestick chart with the Alligator indicator without extra options

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q bot`


------
https://chatgpt.com/codex/tasks/task_e_684557ac90c0832ba934071b248dd280