### PR TITLE
Fix AI article insertion lists

### DIFF
--- a/bot/postgres.py
+++ b/bot/postgres.py
@@ -200,13 +200,21 @@ async def insert_ai_articles(pool, articles):
         else:
             dt = datetime.utcnow()
         news_type = a.get("news_type")
-        if news_type is not None and not isinstance(news_type, list):
+        if isinstance(news_type, list):
+            news_type = [str(x) for x in news_type]
+        elif news_type is not None:
             news_type = [str(news_type)]
+
         topics = a.get("topics")
-        if topics is not None and not isinstance(topics, list):
+        if isinstance(topics, list):
+            topics = [str(x) for x in topics]
+        elif topics is not None:
             topics = [str(topics)]
+
         corr = a.get("correlated_markets")
-        if corr is not None and not isinstance(corr, list):
+        if isinstance(corr, list):
+            corr = [str(x) for x in corr]
+        elif corr is not None:
             corr = [str(corr)]
 
         records.append(


### PR DESCRIPTION
## Summary
- ensure `news_type`, `topics`, and `correlated_markets` arrays contain strings when inserting AI articles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845640a8dbc8328b040fb2fe80a52a2